### PR TITLE
fix Docker image tag

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: kubernetes-pod-restarter
-          image: quay.io/rebuy/kubernetes-pod-restarter
+          image: quay.io/rebuy/kubernetes-pod-restarter:master
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
This will make sure it always pulls the master build, because we do not have anything to update the latest tag.

Nevertheless this does not force a rolling update on deployment.