### PR TITLE
to no omit empty for maxUnavailable

### DIFF
--- a/pkg/apis/lifecycle/v1alpha1/types.go
+++ b/pkg/apis/lifecycle/v1alpha1/types.go
@@ -31,7 +31,7 @@ type PodRestarterSpec struct {
 
 	// MaxUnavailable is the maximum amount of Pods which are allowed to be unavailable among the selected pods.
 	// +optional
-	MaxUnavailable int32 `json:"maxUnavailable,omitempty"`
+	MaxUnavailable int32 `json:"maxUnavailable"`
 
 	// MaxUnavailable is the maximum amount of Pods which are allowed to be unavailable among the selected pods.
 	// +optional


### PR DESCRIPTION
Having a `0` here is actually a valid value and is very different to "not set".